### PR TITLE
#64 - Bug in the meeting form - Date and Time in the past

### DIFF
--- a/web/src/pages/NewMeeting.jsx
+++ b/web/src/pages/NewMeeting.jsx
@@ -254,7 +254,7 @@ function NewMeeting() {
 								name="meetingDate"
 								required
 								value={meetingDate}
-								min={new Date()}
+								min={new Date().toISOString().split("T")[0]}
 								onChange={(e) =>
 									handleMeetingChange("meetingDate", e.target.value)
 								}


### PR DESCRIPTION
…urrent date onward.

## Naming Rules

Name your PR like this: ISSUENUMBER-TITLE-YOURNAME

## Description

Issues with selecting past dates and ensuring the latest arrival time is later than the earliest start time of the meeting have been resolved.

## Related to

Make sure you include the issue number with a hash sign # so Github can link this PR to the right issue, like this:

Fixes #1

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have carefully reviewed my own code
- [ ] I have commented my code
- [ ] I have updated any documentation
